### PR TITLE
Sudo420

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 2017-07-09 Release 0.2.0
 - Bump saz/sudo requirement to 4.2.0+ for Arch Linux bug fix
+- Remove "xorg-server-utils" package, which has been removed from repos.
 
 2016-12-05 Release 0.1.5
 - add management of /etc/conf.d to archlinux_workstation::docker class, as it may not already exist

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
-2017-12-05 Release 0.1.5
+2017-07-09 Release 0.2.0
+- Bump saz/sudo requirement to 4.2.0+ for Arch Linux bug fix
+
+2016-12-05 Release 0.1.5
 - add management of /etc/conf.d to archlinux_workstation::docker class, as it may not already exist
 
 2016-09-01 Release 0.1.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ If you already have those gems installed, make sure they are up-to-date:
 With all dependencies in place and up-to-date we can now run the tests:
 
 ```shell
-% bundle exec rake spec
+% bundle exec rake test
 ```
 
 This will execute all the [rspec tests](http://rspec-puppet.com/) tests
@@ -168,18 +168,12 @@ and so on. rspec tests may have the same kind of dependencies as the
 module they are testing. While the module defines in its [Modulefile](./Modulefile),
 rspec tests define them in [.fixtures.yml](./fixtures.yml).
 
-Some puppet modules also come with [beaker](https://github.com/puppetlabs/beaker)
-tests. These tests spin up a virtual machine under
-[VirtualBox](https://www.virtualbox.org/)) with, controlling it with
-[Vagrant](http://www.vagrantup.com/) to actually simulate scripted test
-scenarios. In order to run these, you will need both of those tools
-installed on your system.
-
-You can run them by issuing the following command
+To run the Beaker-based acceptance tests:
 
 ```shell
 % bundle exec rake spec_clean
-% bundle exec rspec spec/acceptance
+% bundle exec rake spec_prep
+% bundle exec rake beaker
 ```
 
 This will now download a pre-fabricated image configured in the [default node-set](./spec/acceptance/nodesets/default.yml),

--- a/manifests/all.pp
+++ b/manifests/all.pp
@@ -31,10 +31,10 @@ class archlinux_workstation::all {
   include archlinux_workstation::ssh
   include archlinux_workstation::sudo
 
-  class {'archlinux_workstation::xorg': } ->
-  class {'archlinux_workstation::kde': } ->
-  class {'archlinux_workstation::sddm': } ->
-  class {'archlinux_workstation::networkmanager': }
+  class {'archlinux_workstation::xorg': }
+  -> class {'archlinux_workstation::kde': }
+  -> class {'archlinux_workstation::sddm': }
+  -> class {'archlinux_workstation::networkmanager': }
 
   # userapps
   archlinux_workstation::userapps::rvm { $archlinux_workstation::username : }

--- a/manifests/pacman_repo.pp
+++ b/manifests/pacman_repo.pp
@@ -43,8 +43,8 @@ define archlinux_workstation::pacman_repo (
       setting => 'SigLevel',
       value   => $siglevel,
       notify  => Exec['pacman_repo-Sy'],
-    } ->
-    ini_setting { "archlinux_workstation-pacman_repo-${title}-server":
+    }
+    -> ini_setting { "archlinux_workstation-pacman_repo-${title}-server":
       ensure  => present,
       path    => '/etc/pacman.conf',
       section => $repo_name,

--- a/manifests/xorg.pp
+++ b/manifests/xorg.pp
@@ -9,8 +9,7 @@
 # or expose this option to the user.
 #
 # === Actions:
-#   - Install X server required packages xorg-server, xorg-server-utils,
-#     xorg-xinit and mesa.
+#   - Install X server required packages xorg-server, xorg-xinit and mesa.
 #   - Install xorg-apps package group
 #
 class archlinux_workstation::xorg {
@@ -21,7 +20,6 @@ class archlinux_workstation::xorg {
 
   $xorg_packages = ['xorg-server',
                     'xorg-apps',
-                    'xorg-server-utils',
                     'xorg-xinit',
                     'mesa',
                     'xf86-video-vesa',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jantman-archlinux_workstation",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "summary": "Configure an Arch Linux workstation/desktop/laptop",
   "author": "jantman",
   "description": "Provides many classes (and a sane default class/init.pp) for configuring an Arch Linux workstation/laptop/desktop for graphical use.",

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
     },
     {
       "name": "saz/sudo",
-      "version_requirement": ">=3.0.0 <4.0.0"
+      "version_requirement": ">=4.2.0 <5.0.0"
     },
     {
       "name": "saz/ssh",

--- a/spec/acceptance/classes/1_xorg_spec.rb
+++ b/spec/acceptance/classes/1_xorg_spec.rb
@@ -17,7 +17,6 @@ describe 'archlinux_workstation::xorg class' do
 
     packages = [
       'xorg-server',
-      'xorg-server-utils',
       'xorg-xinit',
       'mesa',
       'xf86-video-vesa',

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,10 +1,10 @@
 HOSTS:
-  archlinux-2017.02.01-amd64:
+  archlinux-2017.07.01-amd64:
     roles:
       - master
-    platform: archlinux-2017.02.01-amd64
+    platform: archlinux-2017.07.01-amd64
     box: ogarcia/archlinux-x64
-    box_version: 2017.02.01
+    box_version: 2017.07.01
     hypervisor: vagrant
 CONFIG:
   log_level: verbose

--- a/spec/classes/xorg_spec.rb
+++ b/spec/classes/xorg_spec.rb
@@ -29,7 +29,6 @@ describe 'archlinux_workstation::xorg' do
 
     packages = ['xorg-server',
                 'xorg-apps',
-                'xorg-server-utils',
                 'xorg-xinit',
                 'mesa',
                 'xf86-video-vesa',


### PR DESCRIPTION
- Bump saz/sudo requirement to 4.2.0+ for Arch Linux bug fix
- Remove "xorg-server-utils" package, which has been removed from repos.
- Bump acceptance test image to newer version

