### PR TITLE
0.4.0 with many fixes

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -16,6 +16,7 @@ fixtures:
     staging: "https://github.com/nanliu/puppet-staging.git"
     concat:
       repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
+      ref: "2.2.1"
     docker: "https://github.com/garethr/garethr-docker.git"
     apt:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -16,7 +16,6 @@ fixtures:
     staging: "https://github.com/nanliu/puppet-staging.git"
     concat:
       repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
-      ref: "2.2.1"
     docker: "https://github.com/garethr/garethr-docker.git"
     apt:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,8 +6,12 @@ fixtures:
     sudo:
       repo: "https://github.com/saz/puppet-sudo.git"
       ref: "v4.2.0"
-    ssh: "https://github.com/saz/puppet-ssh.git"
-    firewall: "https://github.com/puppetlabs/puppetlabs-firewall.git"
+    ssh:
+      repo: "https://github.com/saz/puppet-ssh.git"
+      ref: "v3.0.1"
+    firewall:
+      repo: "https://github.com/puppetlabs/puppetlabs-firewall.git"
+      ref: "1.8.0"
     inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
     staging: "https://github.com/nanliu/puppet-staging.git"
     concat:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Pin some dependencies in ``.fixtures.yml`` to fix tests
 - Switch acceptance tests from deprecated ``archimg/base-devel:latest`` Docker image to ``archlinux/base:latest``
 - Fix Puppet4 unit tests by pinning ``puppet-module-posix-dev-r2.1`` version to 0.3.2
-- Relax puppetlabs-concat module version dependency
 - Add ``.sync.yml`` for my [modulesync_configs](https://github.com/jantman/modulesync_configs)
 - Update ``.travis.yml``, ``Gemfile`` and some documentation via modulesync.
 - Fix ``metadata.json`` casing of supported operatingsystem name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - Pin some dependencies in ``.fixtures.yml`` to fix tests
+- Switch acceptance tests from deprecated ``archimg/base-devel:latest`` Docker image to ``archlinux/base:latest``
 - Add ``.sync.yml`` for my [modulesync_configs](https://github.com/jantman/modulesync_configs)
 - Update ``.travis.yml``, ``Gemfile`` and some documentation via modulesync.
 - Fix ``metadata.json`` casing of supported operatingsystem name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Pin some dependencies in ``.fixtures.yml`` to fix tests
 - Add ``.sync.yml`` for my [modulesync_configs](https://github.com/jantman/modulesync_configs)
 - Update ``.travis.yml``, ``Gemfile`` and some documentation via modulesync.
 - Fix ``metadata.json`` casing of supported operatingsystem name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Pin some dependencies in ``.fixtures.yml`` to fix tests
 - Switch acceptance tests from deprecated ``archimg/base-devel:latest`` Docker image to ``archlinux/base:latest``
+- Fix Puppet4 unit tests by pinning ``puppet-module-posix-dev-r2.1`` version to 0.3.2
 - Add ``.sync.yml`` for my [modulesync_configs](https://github.com/jantman/modulesync_configs)
 - Update ``.travis.yml``, ``Gemfile`` and some documentation via modulesync.
 - Fix ``metadata.json`` casing of supported operatingsystem name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Pin some dependencies in ``.fixtures.yml`` to fix tests
 - Switch acceptance tests from deprecated ``archimg/base-devel:latest`` Docker image to ``archlinux/base:latest``
 - Fix Puppet4 unit tests by pinning ``puppet-module-posix-dev-r2.1`` version to 0.3.2
+- Relax puppetlabs-concat module version dependency
 - Add ``.sync.yml`` for my [modulesync_configs](https://github.com/jantman/modulesync_configs)
 - Update ``.travis.yml``, ``Gemfile`` and some documentation via modulesync.
 - Fix ``metadata.json`` casing of supported operatingsystem name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [comment]: # IMPORTANT: Remember to update the links at the bottom of the file!
 
-## [Unreleased]
+## [0.4.0] Released 2019-03-19
 
+- ``kde`` class - stop managing ``phonon-qt4`` packages as they've been removed from the repos
 - Add ``.sync.yml`` for my [modulesync_configs](https://github.com/jantman/modulesync_configs)
 - Update ``.travis.yml``, ``Gemfile`` and some documentation via modulesync.
 - Fix ``metadata.json`` casing of supported operatingsystem name.
@@ -70,7 +71,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - initial module creation
 - migration of a bunch of stuff from https://github.com/jantman/puppet-archlinux-macbookretina
 
-[Unreleased]: https://github.com/jantman/puppet-archlinux-workstation/compare/0.3.2...master
+[0.4.0]: https://github.com/jantman/puppet-archlinux-workstation/compare/0.3.2...0.4.0
 [0.3.2]: https://github.com/jantman/puppet-archlinux-workstation/compare/0.3.1...0.3.2
 [0.3.1]: https://github.com/jantman/puppet-archlinux-workstation/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/jantman/puppet-archlinux-workstation/compare/0.2.1...0.3.0

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,11 @@ minor_version = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
 group :development do
   gem "puppet-module-posix-default-r#{minor_version}",    :require => false, :platforms => "ruby"
   gem "puppet-module-win-default-r#{minor_version}",      :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "puppet-module-posix-dev-r#{minor_version}",        :require => false, :platforms => "ruby"
+  if minor_version == '2.1'
+    gem "puppet-module-posix-dev-r2.1", '0.3.2',   :require => false, :platforms => "ruby"
+  else
+    gem "puppet-module-posix-dev-r#{minor_version}",        :require => false, :platforms => "ruby"
+  end
   gem "puppet-module-win-dev-r#{minor_version}", '0.0.7', :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
   gem "json_pure", '<= 2.0.1',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
@@ -56,11 +60,11 @@ group :system_tests do
   gem "beaker-docker", '>= 0.3.0',                                               :require => false
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')                  
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
   gem "beaker-pe",                                                               :require => false
-  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
+  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
   gem "puppet-blacksmith", '>= 4.1.1',                                           :require => false
   gem "vandamme",                                                                :require => false
   gem "octokit", '~> 4.0',                                                       :require => false

--- a/manifests/kde.pp
+++ b/manifests/kde.pp
@@ -14,9 +14,6 @@ class archlinux_workstation::kde {
 
   # phonon/vlc audio; we install both backends
   $phonon_packages = [
-                      'phonon-qt4',
-                      'phonon-qt4-gstreamer',
-                      'phonon-qt4-vlc',
                       'phonon-qt5',
                       'phonon-qt5-gstreamer',
                       'phonon-qt5-vlc',

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.5 <3.0.0"
+      "version_requirement": ">= 1.2.5"
     },
     {
       "name": "puppetlabs/inifile",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jantman-archlinux_workstation",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "summary": "Configure an Arch Linux workstation/desktop/laptop",
   "author": "jantman",
   "description": "Provides many classes (and a sane default class/init.pp) for configuring an Arch Linux workstation/laptop/desktop for graphical use.",

--- a/spec/acceptance/classes/kde_spec.rb
+++ b/spec/acceptance/classes/kde_spec.rb
@@ -24,9 +24,6 @@ describe 'archlinux_workstation::kde class' do
     end
 
     $phonon_packages = [
-      'phonon-qt4',
-      'phonon-qt4-gstreamer',
-      'phonon-qt4-vlc',
       'phonon-qt5',
       'phonon-qt5-gstreamer',
       'phonon-qt5-vlc',

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -13,6 +13,6 @@ HOSTS:
         opts: ro
     docker_image_commands:
       - 'echo "en_US.UTF-8 UTF-8" > /etc/locale.gen'
-      - 'pacman -S --noconfirm grep tar'
+      - 'pacman -S --noconfirm grep tar which'
 CONFIG:
   trace_limit: 200

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -2,9 +2,9 @@ HOSTS:
   archlinux-current-x64:
     platform: archlinux-current-amd64
     hypervisor: docker
-    image: archimg/base-devel:latest
+    image: archlinux/base:latest
     docker_preserve_image: true
-    docker_cmd: '["/sbin/init"]'
+    docker_cmd: '["/usr/lib/systemd/systemd"]'
     docker_cap_add: ['SYS_ADMIN']
     mount_folders:
       cgroup:
@@ -13,5 +13,6 @@ HOSTS:
         opts: ro
     docker_image_commands:
       - 'echo "en_US.UTF-8 UTF-8" > /etc/locale.gen'
+      - 'pacman -S --noconfirm grep tar'
 CONFIG:
   trace_limit: 200

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -13,6 +13,6 @@ HOSTS:
         opts: ro
     docker_image_commands:
       - 'echo "en_US.UTF-8 UTF-8" > /etc/locale.gen'
-      - 'pacman -S --noconfirm grep tar which'
+      - 'pacman -S --noconfirm grep tar which awk'
 CONFIG:
   trace_limit: 200

--- a/spec/classes/kde_spec.rb
+++ b/spec/classes/kde_spec.rb
@@ -33,9 +33,6 @@ describe 'archlinux_workstation::kde' do
       it { should contain_package('kde-applications-meta').with_ensure('present') }
 
       $phonon_packages = [
-        'phonon-qt4',
-        'phonon-qt4-gstreamer',
-        'phonon-qt4-vlc',
         'phonon-qt5',
         'phonon-qt5-gstreamer',
         'phonon-qt5-vlc',


### PR DESCRIPTION
- Pin some dependencies in ``.fixtures.yml`` to fix tests
- Switch acceptance tests from deprecated ``archimg/base-devel:latest`` Docker image to ``archlinux/base:latest``
- Fix Puppet4 unit tests by pinning ``puppet-module-posix-dev-r2.1`` version to 0.3.2
- ``kde`` class - stop managing ``phonon-qt4`` packages as they've been removed from the repos
- Add ``.sync.yml`` for my [modulesync_configs](https://github.com/jantman/modulesync_configs)
- Update ``.travis.yml``, ``Gemfile`` and some documentation via modulesync.
- Fix ``metadata.json`` casing of supported operatingsystem name.