### PR TITLE
SSH options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [comment]: # IMPORTANT: Remember to update the links at the bottom of the file!
 
-## Unreleased Changes
+## [0.5.0] Released 2020-04-14
 
 - ``sshd_config`` - Remove deprecated ``RSAAuthentication`` and ``UsePrivilegeSeparation`` options
 
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - initial module creation
 - migration of a bunch of stuff from https://github.com/jantman/puppet-archlinux-macbookretina
 
+[0.5.0]: https://github.com/jantman/puppet-archlinux-workstation/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/jantman/puppet-archlinux-workstation/compare/0.3.2...0.4.0
 [0.3.2]: https://github.com/jantman/puppet-archlinux-workstation/compare/0.3.1...0.3.2
 [0.3.1]: https://github.com/jantman/puppet-archlinux-workstation/compare/0.3.0...0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [comment]: # IMPORTANT: Remember to update the links at the bottom of the file!
 
+## Unreleased Changes
+
+- ``sshd_config`` - Remove deprecated ``RSAAuthentication`` and ``UsePrivilegeSeparation`` options
+
 ## [0.4.0] Released 2019-03-19
 
 - Pin some dependencies in ``.fixtures.yml`` to fix tests

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -53,9 +53,7 @@ class archlinux_workstation::ssh (
     'PermitRootLogin'        => $allow_root,
     'Port'                   => [22],
     'PubkeyAuthentication'   => 'yes',
-    'RSAAuthentication'      => 'yes',
     'SyslogFacility'         => 'AUTH',
-    'UsePrivilegeSeparation' => 'sandbox', # "Default for new installations."
     'X11Forwarding'          => 'yes',
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jantman-archlinux_workstation",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "summary": "Configure an Arch Linux workstation/desktop/laptop",
   "author": "jantman",
   "description": "Provides many classes (and a sane default class/init.pp) for configuring an Arch Linux workstation/laptop/desktop for graphical use.",

--- a/spec/acceptance/classes/ssh_spec.rb
+++ b/spec/acceptance/classes/ssh_spec.rb
@@ -37,8 +37,6 @@ describe 'archlinux_workstation::ssh class' do
       its(:content) { should match /PasswordAuthentication no/ }
       its(:content) { should match /PermitRootLogin yes/ }
       its(:content) { should match /PubkeyAuthentication yes/ }
-      its(:content) { should match /RSAAuthentication yes/ }
-      its(:content) { should match /UsePrivilegeSeparation sandbox/ }
       its(:content) { should match /X11Forwarding yes/ }
     end
   end

--- a/spec/classes/ssh_spec.rb
+++ b/spec/classes/ssh_spec.rb
@@ -40,9 +40,7 @@ describe 'archlinux_workstation::ssh' do
                                                         'PermitRootLogin'        => 'no',
                                                         'Port'                   => [22],
                                                         'PubkeyAuthentication'   => 'yes',
-                                                        'RSAAuthentication'      => 'yes',
                                                         'SyslogFacility'         => 'AUTH',
-                                                        'UsePrivilegeSeparation' => 'sandbox',
                                                         'X11Forwarding'          => 'yes',
                                                       }
                                                     })
@@ -67,9 +65,7 @@ describe 'archlinux_workstation::ssh' do
                                                         'PermitRootLogin'        => 'no',
                                                         'Port'                   => [22],
                                                         'PubkeyAuthentication'   => 'yes',
-                                                        'RSAAuthentication'      => 'yes',
                                                         'SyslogFacility'         => 'AUTH',
-                                                        'UsePrivilegeSeparation' => 'sandbox',
                                                         'X11Forwarding'          => 'yes',
                                                         'foo'                    => 'bar',
                                                       }
@@ -93,9 +89,7 @@ describe 'archlinux_workstation::ssh' do
                                                         'PermitRootLogin'        => 'no',
                                                         'Port'                   => [22],
                                                         'PubkeyAuthentication'   => 'yes',
-                                                        'RSAAuthentication'      => 'yes',
                                                         'SyslogFacility'         => 'AUTH',
-                                                        'UsePrivilegeSeparation' => 'sandbox',
                                                         'X11Forwarding'          => 'yes',
                                                       }
                                                     })
@@ -117,9 +111,7 @@ describe 'archlinux_workstation::ssh' do
                                                         'PermitRootLogin'        => 'yes',
                                                         'Port'                   => [22],
                                                         'PubkeyAuthentication'   => 'yes',
-                                                        'RSAAuthentication'      => 'yes',
                                                         'SyslogFacility'         => 'AUTH',
-                                                        'UsePrivilegeSeparation' => 'sandbox',
                                                         'X11Forwarding'          => 'yes',
                                                       }
                                                     })
@@ -142,9 +134,7 @@ describe 'archlinux_workstation::ssh' do
                                                         'PermitRootLogin'        => 'yes',
                                                         'Port'                   => [22],
                                                         'PubkeyAuthentication'   => 'yes',
-                                                        'RSAAuthentication'      => 'yes',
                                                         'SyslogFacility'         => 'AUTH',
-                                                        'UsePrivilegeSeparation' => 'sandbox',
                                                         'X11Forwarding'          => 'yes',
                                                       }
                                                     })
@@ -171,9 +161,7 @@ describe 'archlinux_workstation::ssh' do
                                                         'PermitRootLogin'        => 'no',
                                                         'Port'                   => [22],
                                                         'PubkeyAuthentication'   => 'yes',
-                                                        'RSAAuthentication'      => 'yes',
                                                         'SyslogFacility'         => 'AUTH',
-                                                        'UsePrivilegeSeparation' => 'sandbox',
                                                         'X11Forwarding'          => 'yes',
                                                       }
                                                     })
@@ -198,9 +186,7 @@ describe 'archlinux_workstation::ssh' do
                                                         'PermitRootLogin'        => 'no',
                                                         'Port'                   => [22],
                                                         'PubkeyAuthentication'   => 'yes',
-                                                        'RSAAuthentication'      => 'yes',
                                                         'SyslogFacility'         => 'AUTH',
-                                                        'UsePrivilegeSeparation' => 'sandbox',
                                                         'X11Forwarding'          => 'yes',
                                                       }
                                                     })
@@ -222,9 +208,7 @@ describe 'archlinux_workstation::ssh' do
                                                         'PermitRootLogin'        => 'yes',
                                                         'Port'                   => [22],
                                                         'PubkeyAuthentication'   => 'yes',
-                                                        'RSAAuthentication'      => 'yes',
                                                         'SyslogFacility'         => 'AUTH',
-                                                        'UsePrivilegeSeparation' => 'sandbox',
                                                         'X11Forwarding'          => 'yes',
                                                       }
                                                     })


### PR DESCRIPTION
After Arch updated OpenSSH to 8.2, having these two options in ``sshd_config`` causes incoming connections to fail. Remove them.